### PR TITLE
Resolve obra/superpowers/#24

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "superpowers",
       "source": {
         "source": "url",
-        "url": "https://github.com/nickolasclarke/superpowers.git"
+        "url": "https://github.com/obra/superpowers.git"
       },
       "description": "Core skills library: TDD, debugging, collaboration patterns, and proven techniques",
       "version": "1.0.0",


### PR DESCRIPTION
removes unused key, paired with https://github.com/obra/superpowers/pull/27. See that PR for how I tested. This PR should be merged first, IIUC.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated marketplace metadata by removing the plugin category field to align with current listing requirements. This change does not alter functionality, performance, or error handling. Users may notice the plugin no longer appears under a specific category in marketplace views. No other metadata or structural adjustments were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->