### PR TITLE
Add declutter plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -78,6 +78,16 @@
       "description": "Stop 'Would you like me to continue?' interruptions. Automatically evaluates whether Claude should continue working using Claude-judged decision making.",
       "version": "1.1.5",
       "strict": true
+    },
+    {
+      "name": "declutter",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/anupamchugh/declutter.git"
+      },
+      "description": "Skill + MCP to detect workspace bloat and auto-generate .claudeignore. Fixes Claude Code freezing on large projects.",
+      "version": "1.0.0",
+      "strict": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds the `declutter` plugin to the marketplace.

**Problem:** Claude Code freezes on large workspaces because it indexes everything - 938MB log files, 1GB+ node_modules, 500MB Python venvs.

**Solution:** A skill that scans for bloat, estimates wasted tokens, and creates `.claudeignore` files.

## Features

- Detects Python, Node, Swift, Rust, Go projects
- Finds bloat: venvs, node_modules, build caches, logs, databases
- Estimates wasted tokens (~bytes/4)
- Asks user before creating .claudeignore
- Optional MCP server for power users

## Usage

```
@declutter              # Scan workspace
@declutter --fix        # Scan + create .claudeignore
```

## Repository

https://github.com/anupamchugh/declutter

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the "declutter" plugin to the marketplace. It automatically detects workspace bloat (virtual environments, node modules, build caches, log files), generates .claudeignore files to exclude unnecessary files, and reduces freezing or slowdowns when working with large projects—improving responsiveness and overall project performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->