### PR TITLE
Add 3 plugins: mac-ai-optimizer, social-copy-generator, skill-multi-publisher

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -99,6 +99,36 @@
       "description": "Stop 'Would you like me to continue?' interruptions. Automatically evaluates whether Claude should continue working using Claude-judged decision making.",
       "version": "1.2.0",
       "strict": true
+    },
+    {
+      "name": "mac-ai-optimizer",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/dongsheng123132/mac-ai-optimizer.git"
+      },
+      "description": "Optimize macOS for AI workloads. Reduce idle memory from 6GB to 2.5GB by disabling background services, UI overhead, configuring Docker limits, and enabling SSH. Turn 8GB Mac into AI server node.",
+      "version": "1.0.0",
+      "strict": true
+    },
+    {
+      "name": "social-copy-generator",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/dongsheng123132/social-copy-generator.git"
+      },
+      "description": "Generate platform-optimized social media copy for 6 platforms (Twitter, Xiaohongshu, Jike, WeChat, Video Account, LinkedIn) with HTML one-click-copy output.",
+      "version": "1.0.0",
+      "strict": true
+    },
+    {
+      "name": "skill-multi-publisher",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/dongsheng123132/skill-multi-publisher.git"
+      },
+      "description": "One-command publish skills to ALL major marketplaces: GitHub, ClawHub, and community directories. Auto-validates, generates files, publishes, and submits PRs.",
+      "version": "2.0.0",
+      "strict": true
     }
   ]
 }


### PR DESCRIPTION
## 3 New Plugins

### 1. mac-ai-optimizer
Optimize macOS for AI workloads. Reduce idle memory from ~6GB to ~2.5GB. Includes 7 tools: system_report, optimize_memory, reduce_ui, docker_optimize, enable_ssh, full_optimize, revert_all.

### 2. social-copy-generator
Generate platform-optimized social media copy for 6 platforms (Twitter, Xiaohongshu, Jike, WeChat Moments, Video Account, LinkedIn) with HTML one-click-copy page output.

### 3. skill-multi-publisher
One-command publish skills to ALL major marketplaces: GitHub (npx skills), ClawHub, and community directories. Auto-validates, generates missing files, publishes, and submits PRs.

All 3 are published on GitHub and ClawHub, tested in Claude Code CLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Three new plugins are now available in the marketplace: Mac AI Optimizer, Social Copy Generator, and Skill Multi-Publisher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->