### PR TITLE
Add shopify-web-scraper skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -99,6 +99,16 @@
       "description": "Stop 'Would you like me to continue?' interruptions. Automatically evaluates whether Claude should continue working using Claude-judged decision making.",
       "version": "1.2.0",
       "strict": true
+    },
+    {
+      "name": "shopify-web-scraper",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/eyes0729/shopify-web-scraper-skill.git"
+      },
+      "description": "Web scraping patterns for Shopify App Store research: extract reviews, usage duration, pricing, and feature history. Includes Wayback Machine snapshots and general web extraction. Primarily designed for Shopify App Store competitive research.",
+      "version": "1.0.0",
+      "strict": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `shopify-web-scraper` plugin to the marketplace catalog
- Scraping patterns for Shopify App Store research: reviews, usage duration, pricing, and feature history via Wayback Machine
- Includes general-purpose web extraction fallback patterns
- Tool priority: WebFetch → curl+python3 → dev-browser

## Plugin Details

- **Repository**: https://github.com/eyes0729/shopify-web-scraper-skill
- **Version**: 1.0.0
- **Skill name**: `shopify-web-scraper`

## What users get

- Pattern 1: Shopify App Store reviews + usage duration extraction
- Pattern 2: App info & pricing scraping
- Pattern 3: Wayback Machine historical snapshot retrieval
- Pattern 4: General web page content extraction
- Common issues table with fixes (403, JS rendering, UTF-8, rate limits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)