### PR TITLE
Add extract-alpha: background removal via difference matting

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -99,6 +99,16 @@
       "description": "Stop 'Would you like me to continue?' interruptions. Automatically evaluates whether Claude should continue working using Claude-judged decision making.",
       "version": "1.2.0",
       "strict": true
+    },
+    {
+      "name": "extract-alpha",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/furic/extract-alpha-skill.git"
+      },
+      "description": "Remove background from AI-generated images using two-pass difference matting. Generate the same image on white and black backgrounds, then extract pixel-perfect transparency.",
+      "version": "1.0.0",
+      "strict": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `extract-alpha` plugin to the marketplace
- Removes backgrounds from AI-generated images using two-pass difference matting
- Works with white/black background image pairs to produce clean transparent PNGs

## Plugin Details

- **Repository**: https://github.com/furic/extract-alpha-skill
- **Skill name**: `extract-alpha`
- **Author**: furic (Richard Fu)

## What it does

AI image generators (Gemini, DALL-E, Midjourney, etc.) don't support transparent backgrounds. This skill solves that by having users generate the same image twice — once on white, once on black — then mathematically extracting the exact alpha channel from the pixel differences.

- `/extract-alpha path/to/image.png` command
- Pixel-perfect alpha extraction (no AI guessing, no edge artifacts)
- Handles minor size differences between AI-generated image pairs
- Only requires Python + Pillow