### PR TITLE
Add technical-change-skill plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -99,6 +99,16 @@
       "description": "Stop 'Would you like me to continue?' interruptions. Automatically evaluates whether Claude should continue working using Claude-judged decision making.",
       "version": "1.2.0",
       "strict": true
+    },
+    {
+      "name": "technical-change-skill",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Elkidogz/technical-change-skill.git"
+      },
+      "description": "Structured code change tracking with JSON records, state machine validation, AI session handoff, and accessible HTML output. 9 commands for full change lifecycle.",
+      "version": "1.0.0",
+      "strict": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds the **technical-change-skill** plugin to the marketplace.

- Structured code change tracking with JSON records and state machine validation
- AI session handoff for bot continuity across sessions
- Accessible HTML output (WCAG AA+, dark theme)
- 9 commands covering the full change lifecycle
- Python stdlib only — zero external dependencies

## Repository

https://github.com/Elkidogz/technical-change-skill — MIT License

The repo already includes `.claude-plugin/plugin.json` for plugin compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)