### PR TITLE
Add Shipwright — autonomous app builder plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -99,6 +99,16 @@
       "description": "Stop 'Would you like me to continue?' interruptions. Automatically evaluates whether Claude should continue working using Claude-judged decision making.",
       "version": "1.2.0",
       "strict": true
+    },
+    {
+      "name": "shipwright",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Wynelson94/shipwright.git"
+      },
+      "description": "Describe your app in plain English \u2014 Shipwright builds, tests, and deploys it autonomously. 9-phase pipeline, 4 stacks, enterprise-grade safety hooks.",
+      "version": "1.0.0",
+      "strict": true
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -75,6 +75,28 @@ Add this marketplace to Claude Code:
 
 ---
 
+### Shipwright
+
+**Description:** Describe your app in plain English — Shipwright builds, tests, and deploys it autonomously. 9-phase pipeline, 4 stacks, enterprise-grade safety hooks.
+
+**Categories:** App Builder, Autonomous Agent, Pipeline
+
+**Install:**
+```bash
+/plugin install shipwright@superpowers-marketplace
+```
+
+**What you get:**
+- Autonomous 9-phase build pipeline (scaffold, implement, test, lint, security, docs, deploy)
+- 4 production-ready stacks (Next.js, FastAPI, Express, Static)
+- `/shipwright:build`, `/shipwright:enhance`, `/shipwright:stacks`, `/shipwright:projects` commands
+- Enterprise-grade safety hooks (test coverage, security audit, lint-clean)
+- Powered by [product-agent](https://pypi.org/project/product-agent/) on PyPI
+
+**Repository:** https://github.com/Wynelson94/shipwright
+
+---
+
 ## Marketplace Structure
 
 ```


### PR DESCRIPTION
## Summary

- Adds **Shipwright** to the marketplace catalog and README
- Shipwright builds, tests, and deploys complete applications from plain-English descriptions
- 9-phase autonomous pipeline, 4 production-ready stacks, enterprise-grade safety hooks
- Powered by [product-agent](https://pypi.org/project/product-agent/) on PyPI

## Plugin Details

- **Name**: Shipwright
- **Repository**: https://github.com/Wynelson94/shipwright
- **Skills**: `/shipwright:build`, `/shipwright:enhance`, `/shipwright:stacks`, `/shipwright:projects`
- **Category**: App Builder / Autonomous Agent

## What's Included

- `.claude-plugin/marketplace.json` — Plugin entry added (follows existing format with `source.url` pointing to git repo)
- `README.md` — Listing added with install instructions, features, and repository link

🤖 Generated with [Claude Code](https://claude.com/claude-code)