### PR TITLE
Add sdd-superpowers plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -109,6 +109,16 @@
       "description": "Stop 'Would you like me to continue?' interruptions. Automatically evaluates whether Claude should continue working using Claude-judged decision making.",
       "version": "1.2.0",
       "strict": true
+    },
+    {
+      "name": "sdd-superpowers",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/hllj/sdd-superpowers.git"
+      },
+      "description": "Specification-Driven Development (SDD) for Claude Code: write specs first, generate code from them. 8-skill workflow: brainstorm → specify → research → plan → tasks → execute → review.",
+      "version": "1.0.0",
+      "strict": true
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -96,6 +96,27 @@ Add this marketplace to Claude Code:
 
 ---
 
+### SDD Superpowers
+
+**Description:** Specification-Driven Development (SDD) for Claude Code — write specs first, generate code from them
+
+**Categories:** Workflow, Planning, Specification, TDD
+
+**Install:**
+```bash
+/plugin install sdd-superpowers@superpowers-marketplace
+```
+
+**What you get:**
+- 8-skill SDD workflow: `sdd-brainstorm` → `sdd-specify` → `sdd-research` → `sdd-plan` → `sdd-tasks` → `sdd-execute` → `sdd-review`
+- Four hard gates: no code without a failing test, no completion claim without verification evidence
+- Bundled support skills (TDD, systematic-debugging, verification-before-completion, etc.)
+- Spec → plan → tasks → subagent dispatch pipeline
+
+**Repository:** https://github.com/hllj/sdd-superpowers
+
+---
+
 ## Marketplace Structure
 
 ```


### PR DESCRIPTION
## Summary

Closes #41

- Adds `sdd-superpowers` to the marketplace catalog (`.claude-plugin/marketplace.json`)
- Adds plugin documentation section to `README.md`

## About the plugin

**sdd-superpowers** implements Specification-Driven Development (SDD) for Claude Code — a methodology where specifications are the source of truth and code is their generated expression.

**8-skill workflow:**
`sdd-brainstorm` → `sdd-specify` → `sdd-research` → `sdd-plan` → `sdd-tasks` → `sdd-execute` → `sdd-review`

**Four hard gates enforced:**
- No plan without an approved spec
- No tasks without a plan
- No code without a prior failing test
- No completion claim without fresh verification evidence

**Repository:** https://github.com/hllj/sdd-superpowers

**Submitted by:** hllj (vanhop3499@gmail.com)