### PR TITLE
feat: add claude-mem plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -109,6 +109,16 @@
       "description": "Stop 'Would you like me to continue?' interruptions. Automatically evaluates whether Claude should continue working using Claude-judged decision making.",
       "version": "1.2.0",
       "strict": true
+    },
+    {
+      "name": "claude-mem",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/thedotmack/claude-mem.git"
+      },
+      "description": "Persistent memory system for Claude Code - seamlessly preserve context across sessions with hooks, MCP server, and semantic search",
+      "version": "12.1.0",
+      "strict": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds [claude-mem](https://github.com/thedotmack/claude-mem) (v12.1.0) to the marketplace
- claude-mem is a persistent memory system for Claude Code that preserves context across sessions using hooks, an MCP server, and semantic search

## Plugin details

- **Name:** `claude-mem`
- **Source:** https://github.com/thedotmack/claude-mem
- **Version:** 12.1.0
- **Description:** Persistent memory system for Claude Code - seamlessly preserve context across sessions with hooks, MCP server, and semantic search