### PR TITLE
Add Origin plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -101,6 +101,18 @@
       "strict": true
     },
     {
+      "name": "origin",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/7xuanlu/origin.git",
+        "path": "plugin",
+        "ref": "main"
+      },
+      "description": "AI work memory for Claude Code. Carries sessions, decisions, lessons, project context, recall, distillation, review, and handoff through Origin's local daemon and MCP server.",
+      "version": "0.7.0",
+      "strict": true
+    },
+    {
       "name": "double-shot-latte",
       "source": {
         "source": "url",


### PR DESCRIPTION
Adds Origin to the Superpowers marketplace as a Claude Code plugin.\n\nOrigin is AI work memory for Claude Code and MCP clients: it carries sessions, decisions, lessons, project context, recall, distillation, review, and handoff through a local daemon and MCP server.\n\nImplementation notes:\n- Uses `source: git-subdir` because Origin's Claude Code plugin lives under `plugin/` in the monorepo.\n- Version matches `plugin/.claude-plugin/plugin.json` in 7xuanlu/origin.\n\nVerification:\n- Parsed `.claude-plugin/marketplace.json` with Node JSON.parse.\n- Verified the Origin repo contains `plugin/.claude-plugin/plugin.json` and plugin version `0.7.0`.