### PR TITLE
Add dingdong plugin — cross-platform audio feedback

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -109,6 +109,16 @@
       "description": "Stop 'Would you like me to continue?' interruptions. Automatically evaluates whether Claude should continue working using Claude-judged decision making.",
       "version": "1.2.0",
       "strict": true
+    },
+    {
+      "name": "dingdong",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/WhoKnowsNothing/claude-code-dingdong.git"
+      },
+      "description": "Cross-platform audio feedback for Claude Code — plays customizable sounds on Stop, Notification, PermissionRequest, Elicitation, and TeammateIdle events. Includes control panel, 13 WAV sounds, and config UI. Windows/macOS/Linux.",
+      "version": "2.0.0",
+      "strict": true
     }
   ]
 }


### PR DESCRIPTION
## DingDong — Audio Feedback for Claude Code

Cross-platform plugin that plays customizable sounds on Claude Code events:

- **Stop** — task completion
- **Notification** — system notifications  
- **PermissionRequest** — permission prompts
- **Elicitation** — clarification questions
- **TeammateIdle** — agent idle alerts

### What's included
- 13 custom WAV sound effects
- WinForms control panel (Windows) — Settings / Reinstall / Uninstall
- PowerShell config UI — per-event sound picker + preview
- Self-extracting cross-platform installer (bash)
- Safe uninstall preserves default config + sounds

### Repository
https://github.com/WhoKnowsNothing/claude-code-dingdong

### License
MIT

🤖 Generated with [Claude Code](https://claude.com/claude-code)