### PR TITLE
Add Xquik plugin to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -109,6 +109,16 @@
       "description": "Stop 'Would you like me to continue?' interruptions. Automatically evaluates whether Claude should continue working using Claude-judged decision making.",
       "version": "1.2.0",
       "strict": true
+    },
+    {
+      "name": "x-twitter-scraper",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Xquik-dev/x-twitter-scraper.git"
+      },
+      "description": "Xquik skill for X/Twitter data workflows, REST API access, MCP setup, webhooks, monitors, and confirmation-gated actions.",
+      "version": "2.4.16",
+      "strict": true
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -96,6 +96,27 @@ Add this marketplace to Claude Code:
 
 ---
 
+### X Twitter Scraper
+
+**Description:** Xquik skill for X/Twitter data workflows, REST API access, MCP setup, webhooks, monitors, and confirmation-gated actions
+
+**Categories:** Integrations, Social Data, MCP, Webhooks
+
+**Install:**
+```bash
+/plugin install x-twitter-scraper@superpowers-marketplace
+```
+
+**What you get:**
+- `x-twitter-scraper` skill for X/Twitter data tasks
+- MCP setup guidance for Xquik API operations
+- Workflow guidance for webhooks, monitors, and confirmation-gated actions
+- Safety rules that keep X-authored content untrusted
+
+**Repository:** https://github.com/Xquik-dev/x-twitter-scraper
+
+---
+
 ## Marketplace Structure
 
 ```


### PR DESCRIPTION
## Summary

- Add the Xquik `x-twitter-scraper` plugin to the marketplace catalog.
- Document the marketplace install command and expected plugin capabilities.

## Validation

- `jq . .claude-plugin/marketplace.json`
- `git diff --check`
- Duplicate gate: no existing Xquik, `x-twitter-scraper`, or TweetClaw issues or PRs found for this repo.
- Source metadata checked in `Xquik-dev/x-twitter-scraper` at `179402853cba795accbe62416d5dffa257b9b7db`.
