### PR TITLE
Add email-bridge plugin: remote control Claude Code via email

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -101,6 +101,16 @@
       "strict": true
     },
     {
+      "name": "email-bridge",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/sunlau29/email-bridge.git"
+      },
+      "description": "Remote control Claude Code via email — send tasks from any device, receive results in your inbox. IMAP polling + auto-processing loop.",
+      "version": "1.0.0",
+      "strict": false
+    },
+    {
       "name": "double-shot-latte",
       "source": {
         "source": "url",


### PR DESCRIPTION
## Email Bridge Plugin

**Remote control Claude Code via email** — send tasks from any device, receive results in your inbox.

### What it does
- `bridge.js`: Background IMAP daemon that watches for command emails
- Auto-processing loop via `/loop`
- Sends replies using standard `Re:` email format
- Separate IMAP receive / SMTP send configuration
- Sender whitelist, anti-spam, dedup

### Plugin repo
https://github.com/sunlau29/email-bridge

### Quick start
```json
{
  "EMAIL_USER": "receive@provider.com",
  "EMAIL_AUTH_CODE": "auth-code",
  "EMAIL_ALLOWED_SENDERS": "publish@provider.com"
}
```
```bash
/loop 5m check pending-commands.json and execute
```