### PR TITLE
Add Agent Safety Preflight plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -109,6 +109,16 @@
       "description": "Stop 'Would you like me to continue?' interruptions. Automatically evaluates whether Claude should continue working using Claude-judged decision making.",
       "version": "1.2.0",
       "strict": true
+    },
+    {
+      "name": "agent-safety-preflight",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/el-zachariah/ai-agent-safety-starter-pack.git"
+      },
+      "description": "Claude Code /agent-preflight command for running a lightweight repo safety scan before tool-enabled agent work.",
+      "version": "0.1.0",
+      "strict": true
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -96,6 +96,26 @@ Add this marketplace to Claude Code:
 
 ---
 
+### Agent Safety Preflight
+
+**Description:** Claude Code `/agent-preflight` command for running a lightweight repo safety scan before tool-enabled agent work.
+
+**Categories:** Claude Code, Agent Safety, Workflow, Preflight
+
+**Install:**
+```bash
+/plugin install agent-safety-preflight@superpowers-marketplace
+```
+
+**What you get:**
+- `/agent-preflight` slash command for prompting a Green / Yellow / Red preflight before tool-enabled agent work.
+- Lightweight scanner and handoff language in the public starter-pack repo.
+- A clear upgrade path for teams that need the full checklist/templates after a Yellow or Red scan.
+
+**Repository:** https://github.com/el-zachariah/ai-agent-safety-starter-pack
+
+---
+
 ## Marketplace Structure
 
 ```


### PR DESCRIPTION
## Summary
- Add `agent-safety-preflight` to the Superpowers Marketplace catalog.
- Document the `/agent-preflight` install snippet in the README.

## Why this fits
This is a Claude Code slash-command plugin for running a lightweight repo safety preflight before tool-enabled agent work. It points to the public starter-pack repo, not a private signup flow.

## Verification
- `python3 -m json.tool .claude-plugin/marketplace.json`
- README install command added: `/plugin install agent-safety-preflight@superpowers-marketplace`
