### PR TITLE
Add Agent Safety Preflight plugin listing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -109,6 +109,16 @@
       "description": "Stop 'Would you like me to continue?' interruptions. Automatically evaluates whether Claude should continue working using Claude-judged decision making.",
       "version": "1.2.0",
       "strict": true
+    },
+    {
+      "name": "agent-safety-preflight",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/el-zachariah/ai-agent-safety-starter-pack.git"
+      },
+      "description": "Claude Code /agent-preflight command plus a lite repo scanner for generating before-agent safety receipts in small team repos.",
+      "version": "0.1.0",
+      "strict": true
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -96,6 +96,26 @@ Add this marketplace to Claude Code:
 
 ---
 
+### Agent Safety Preflight
+
+**Description:** Claude Code `/agent-preflight` command plus a lite repo scanner for generating before-agent safety receipts in small team repos
+
+**Categories:** Claude Code, Security, Workflows, Agent Safety
+
+**Install:**
+```bash
+/plugin install agent-safety-preflight@superpowers-marketplace
+```
+
+**What you get:**
+- `/agent-preflight` slash command for pre-agent repo checks
+- Lite Python scanner with Green / Yellow / Red decision output
+- CI, review-comment, and handoff examples for safer agent sessions
+
+**Repository:** https://github.com/el-zachariah/ai-agent-safety-starter-pack
+
+---
+
 ## Marketplace Structure
 
 ```


### PR DESCRIPTION
## Summary
- Adds Agent Safety Preflight to the Superpowers Marketplace catalog.
- Lists the free Claude Code `/agent-preflight` plugin source from `el-zachariah/ai-agent-safety-starter-pack`.
- Updates the README with install and capability notes.

## Verification
- Parsed `.claude-plugin/marketplace.json` as JSON and added one non-duplicate plugin entry.
- Kept the listing pointed at the free GitHub repository, not a paid checkout page.
