### PR TITLE
Add agent safety preflight plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Skills, workflows, and productivity tools",
-    "version": "1.0.13"
+    "version": "1.0.14"
   },
   "plugins": [
     {
@@ -108,6 +108,16 @@
       },
       "description": "Stop 'Would you like me to continue?' interruptions. Automatically evaluates whether Claude should continue working using Claude-judged decision making.",
       "version": "1.2.0",
+      "strict": true
+    },
+    {
+      "name": "agent-safety-preflight",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/el-zachariah/ai-agent-safety-starter-pack.git"
+      },
+      "description": "Claude Code slash command and skill for generating a local repo-risk preflight receipt before autonomous AI-agent edits.",
+      "version": "0.1.0",
       "strict": true
     }
   ]

--- a/README.md
+++ b/README.md
@@ -96,6 +96,27 @@ Add this marketplace to Claude Code:
 
 ---
 
+
+### Agent Safety Preflight
+
+**Description:** Claude Code slash command and skill for generating a local repo-risk preflight receipt before autonomous AI-agent edits
+
+**Categories:** Claude Code, Agent Safety, Preflight, Repo Safety
+
+**Install:**
+```bash
+/plugin install agent-safety-preflight@superpowers-marketplace
+```
+
+**What you get:**
+- `/agent-preflight` command for a quick repo-risk receipt before agent edits
+- `agent-safety-preflight` skill for repeatable preflight checks
+- Sample local scanner output and handoff prompts for safer Claude Code/Codex/Cursor work
+
+**Repository:** https://github.com/el-zachariah/ai-agent-safety-starter-pack
+
+---
+
 ## Marketplace Structure
 
 ```


### PR DESCRIPTION
Adds the free `agent-safety-preflight` Claude Code plugin/skill package to the Superpowers Marketplace catalog.

Why it fits:
- Claude Code focused command/skill package, source-installable from a public GitHub repo
- Helps agents generate a local repo-risk preflight receipt before autonomous edits
- Catalog entry points to the free source repo only; no paid offer link in this marketplace PR

Validation:
- `python3 -m json.tool .claude-plugin/marketplace.json`
- `git diff --check`
