### PR TITLE
Add hf-model-architecture plugin (Hugging Face / hfviewer capture)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Skills, workflows, and productivity tools",
-    "version": "1.0.13"
+    "version": "1.0.14"
   },
   "plugins": [
     {
@@ -108,6 +108,16 @@
       },
       "description": "Stop 'Would you like me to continue?' interruptions. Automatically evaluates whether Claude should continue working using Claude-judged decision making.",
       "version": "1.2.0",
+      "strict": true
+    },
+    {
+      "name": "hf-model-architecture",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/ingeniousfrog/Layerdex.git"
+      },
+      "description": "Capture Hugging Face model architecture diagrams and hfviewer metadata as PNG + JSON. Agent skill with Playwright CLI for Claude Code, Codex CLI, and Cursor.",
+      "version": "0.1.0",
       "strict": true
     }
   ]

--- a/README.md
+++ b/README.md
@@ -96,6 +96,27 @@ Add this marketplace to Claude Code:
 
 ---
 
+### HF Model Architecture
+
+**Description:** Capture Hugging Face model architecture diagrams and hfviewer metadata as PNG + JSON
+
+**Categories:** Hugging Face, Model Visualization, Agent Skills
+
+**Install:**
+```bash
+/plugin install hf-model-architecture@superpowers-marketplace
+```
+
+**What you get:**
+- `hf-model-architecture` skill for capturing hfviewer architecture graphs
+- Playwright CLI to export PNG diagrams and structured JSON metadata
+- Works with public Hugging Face models via hfviewer.com
+- Install script for Claude Code, Codex CLI, and Cursor
+
+**Repository:** https://github.com/ingeniousfrog/Layerdex
+
+---
+
 ## Marketplace Structure
 
 ```


### PR DESCRIPTION
## Summary

- Adds **hf-model-architecture** to the marketplace catalog, sourced from [ingeniousfrog/Layerdex](https://github.com/ingeniousfrog/Layerdex).
- Captures Hugging Face model architecture diagrams as PNG and hfviewer right-panel metadata as structured JSON.
- Includes Playwright CLI automation and an agent skill installable via Claude Code, Codex CLI, and Cursor.

## Install (after merge)

```bash
/plugin marketplace add obra/superpowers-marketplace
/plugin install hf-model-architecture@superpowers-marketplace
```

## Test plan

- [x] Plugin entry added to `.claude-plugin/marketplace.json` with `strict: true`
- [x] README documents install command and repository link
- [x] Source repo includes `.claude-plugin/plugin.json` and `skills/hf-model-architecture/SKILL.md`
- [x] Source repo unit tests pass (`npm test` — 5/5)
- [x] Live example artifacts included: [FLUX.1-dev architecture PNG](https://github.com/ingeniousfrog/Layerdex/blob/main/skills/hf-model-architecture/examples/flux1-dev-level3-structure.png)

## Notes

- Depends on third-party rendering at [hfviewer.com](https://hfviewer.com/) for public Hugging Face models.
- Does not download model weights; exports reproducible PNG + JSON artifacts only.


Made with [Cursor](https://cursor.com)