### PR TITLE
Add spring-boot4-upgrade migration skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -109,6 +109,16 @@
       "description": "Stop 'Would you like me to continue?' interruptions. Automatically evaluates whether Claude should continue working using Claude-judged decision making.",
       "version": "1.2.0",
       "strict": true
+    },
+    {
+      "name": "spring-boot4-upgrade",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/dingdaoyi/spring-boot4-upgrade-agent.git"
+      },
+      "description": "Audit, plan, execute, and verify Spring Boot 3.5 to 4.x upgrades. 21 production-verified runtime traps: Jackson 3 migration, Security 7 lambda DSL, virtual threads, JVM flags, modular starters, K8s crashloop triage. Works with Claude Code and Codex CLI.",
+      "version": "1.0.0",
+      "strict": false
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -116,7 +116,7 @@
         "source": "url",
         "url": "https://github.com/dingdaoyi/spring-boot4-upgrade-agent.git"
       },
-      "description": "Audit, plan, execute, and verify Spring Boot 3.5 to 4.x upgrades. 21 production-verified runtime traps: Jackson 3 migration, Security 7 lambda DSL, virtual threads, JVM flags, modular starters, K8s crashloop triage. Works with Claude Code and Codex CLI.",
+      "description": "Evidence-first Spring Boot 3.5 to 4.x migration skill for Maven and Gradle. Covers modular starters, Jackson 3, Spring Security 7, test migration, dependency and bytecode diagnosis, JVM and container checks, database migrations, and Kubernetes runtime verification. Supports Claude Code and Codex.",
       "version": "1.0.0",
       "strict": false
     }


### PR DESCRIPTION
## What

Add `spring-boot4-upgrade` to the Superpowers marketplace.

This is an evidence-first agent skill for migrating Maven or Gradle applications from Spring Boot 3.5 to Spring Boot 4.x. It treats the upgrade as a staged runtime migration rather than a version-only build change.

## Coverage

- Spring Boot 4 modular starters and package changes
- Jackson 3 migration with a time-boxed Jackson 2 bridge strategy
- Spring Security 7 and Spring Boot test migration
- Dependency convergence and bytecode linkage diagnosis
- Database migration, JVM, container, virtual-thread, and Kubernetes checks
- Runtime verification for startup, APIs, serialization, security, and database behavior

The skill avoids stale universal version tables and requires verification against the selected Spring Boot maintenance release, upstream compatibility information, and the resolved project dependency graph.

Supports Claude Code and Codex. MIT licensed.

Source: https://github.com/dingdaoyi/spring-boot4-upgrade-agent

## Verify

```text
/plugin marketplace add obra/superpowers-marketplace
/plugin install spring-boot4-upgrade@superpowers-marketplace
```
