### PR TITLE
Add superpowers-safe plugin (safety-hardened fork)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -109,6 +109,16 @@
       "description": "Stop 'Would you like me to continue?' interruptions. Automatically evaluates whether Claude should continue working using Claude-judged decision making.",
       "version": "1.2.0",
       "strict": true
+    },
+    {
+      "name": "superpowers-safe",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/JFWaskin/superpowers-safe.git"
+      },
+      "description": "Safety-hardened fork of Superpowers with a mandatory 5-gate safety-check preflight (resource budget, command risk scan, loop/spend limits, secret/PII scan, scope confirmation) before any skill runs. All 14 upstream skills included byte-identical, plus a new opt-in safety-check skill and a defense-in-depth PreToolUse hook.",
+      "version": "6.3.0",
+      "strict": true
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -96,6 +96,31 @@ Add this marketplace to Claude Code:
 
 ---
 
+### Superpowers (Safe)
+
+**Description:** Safety-hardened fork of Superpowers. Same 14 upstream skills byte-identical, plus a mandatory `safety-check` preflight with five hard gates (resource budget, command risk scan, loop/spend limits, secret/PII scan, scope confirmation) before any skill runs.
+
+**Categories:** Testing, Debugging, Collaboration, Meta, Safety, Preflight
+
+**Install:**
+```bash
+/plugin install superpowers-safe@superpowers-marketplace
+```
+
+**What you get:**
+- All 14 upstream Superpowers skills (brainstorming, subagent-driven-development, TDD, systematic-debugging, writing-plans, etc.)
+- New `safety-check` skill (5 hard gates + 10 never-override destructive-operation limits)
+- Defense-in-depth `PreToolUse` hook (`scripts/safety-guard.py`) that blocks destructive bash at the tool layer
+- Cross-runtime packaging: Claude Code, Codex, Cursor, Kimi, Gemini, Hermes, OpenCode, Pi
+- Full eval protocol in `docs/eval-protocol.md` (RED-GREEN-REFACTOR for safety-gate changes)
+- Independent sync from upstream via `scripts/sync-upstream.sh`
+
+**Repository:** https://github.com/JFWaskin/superpowers-safe
+
+> Note: this is a different scope from the `agent-safety-preflight` plugin in PR #62. That one is a single `/agent-preflight` slash command for lightweight repo scanning; this one is the full Superpowers skills library with a safety preflight embedded. Different product, different value.
+
+---
+
 ## Marketplace Structure
 
 ```


### PR DESCRIPTION
## Summary

Adds `superpowers-safe` to the marketplace catalog. A safety-hardened fork of `obra/superpowers` with a mandatory 5-gate `safety-check` preflight before any skill runs.

## What's in the plugin

- All 14 upstream Superpowers skills (byte-identical to upstream)
- A new `safety-check` skill with 5 hard gates (resource budget, command risk scan, loop/spend limits, secret/PII scan, scope confirmation) and 10 never-override destructive-operation limits
- A defense-in-depth `PreToolUse` hook (`scripts/safety-guard.py`) that blocks destructive bash at the tool layer
- Cross-runtime packaging for Claude Code, Codex, Cursor, Kimi, Gemini, Hermes, OpenCode, Pi
- A `docs/eval-protocol.md` describing the RED-GREEN-REFACTOR process for any future safety-gate change
- A `scripts/sync-upstream.sh` for keeping the fork current with `obra/superpowers` `dev`
- An opt-in DeepSeek Harness bridge (Cordis plugin + `cordis.yml` overlay) at `fork/deepseek-harness-bridge/` — see `docs/compatibility.md` row 14. Ships in the `fork/deepseek-harness-skills` branch; ask-PR to obra/superpowers is tracked at #2152.

## Why this is a different scope from #62

`#62` (`agent-safety-preflight` by `@el-zachariah`) is a single `/agent-preflight` slash command for lightweight repo scanning — a useful, focused tool, but a thin one.

This PR adds the full Superpowers skills library with a safety preflight *embedded* into `using-superpowers`. It is a different product: users who want the Superpowers workflow choose this; users who only want a preflight checker choose #62.

## Related

- Upstream discussion issue (separate, longer-running): `obra/superpowers#2111` (2026-08-08). **This marketplace listing is independent of it** — the plugin is installable either way.
- License: MIT, matching upstream.
- Repo: https://github.com/JFWaskin/superpowers-safe (v6.3.0, commit `c599511` on `dev`)
- CI: green at `JFWaskin/superpowers-safe/.github/workflows/test.yml`

If you'd rather wait until the upstream discussion in #2111 resolves before deciding on this listing, I am happy to close this PR. If you have a different framing in mind, also happy to revise.

— JFWaskin